### PR TITLE
Update to latest ctor crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,13 +138,34 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "ctor"
-version = "0.2.7"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad291aa74992b9b7a7e88c38acbbf6ad7e107f1d90ee8775b7bc1fc3394f485c"
+checksum = "67773048316103656a637612c4a62477603b777d91d9c62ff2290f9cde178fdb"
 dependencies = [
- "quote",
- "syn",
+ "ctor-proc-macro",
+ "dtor",
 ]
+
+[[package]]
+name = "ctor-proc-macro"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2931af7e13dc045d8e9d26afccc6fa115d64e115c9c84b1166288b46f6782c2"
+
+[[package]]
+name = "dtor"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e58a0764cddb55ab28955347b45be00ade43d4d6f3ba4bf3dc354e4ec9432934"
+dependencies = [
+ "dtor-proc-macro",
+]
+
+[[package]]
+name = "dtor-proc-macro"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
 name = "env_filter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ clap-verbosity-flag = { version = "2", optional = true }
 
 [dev-dependencies]
 # Used to register logging at setup when running tests
-ctor = "0.2"
+ctor = "0.5"
 env_logger = "0.11"
 
 [features]


### PR DESCRIPTION
This fixes a warning:

```
warning: unexpected `cfg` condition value: `used_linker`
   --> src/lib.rs:238:1
    |
238 | #[ctor::ctor]
    | ^^^^^^^^^^^^^
```